### PR TITLE
Fix `report` so that it reports the start and end times

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -443,8 +443,8 @@ impl Doug {
         }
         let mut message = format!(
             "{start} -> {end}\n",
-            start = start_date.format("%A %-d %B %Y").to_string().blue(),
-            end = end_date.format("%A %-d %B %Y").to_string().blue()
+            start = from_date_parsed.format("%A %-d %B %Y").to_string().blue(),
+            end = to_date_parsed.format("%A %-d %B %Y").to_string().blue()
         );
         results.sort();
         for (project, duration) in &results {

--- a/src/main.rs
+++ b/src/main.rs
@@ -240,9 +240,13 @@ fn main() {
     };
 
     match results {
-        Ok(m) => if let Some(m) = m {
-            println!("{}", m)
+        Ok(Some(m)) => {
+            // There are some inconsistencies for outputs so some commands return new lines and
+            // some don't
+            println!("{}", m.trim_right())
         },
+        // nothing to print
+        Ok(None) => {},
         Err(e) => {
             eprintln!("{} {}", "Error:".red(), e);
             process::exit(1)


### PR DESCRIPTION
Right now, it gives the first and last dates that a period occurred in
the actual start and end dates.

fixed excess new lines being printed